### PR TITLE
filling the payload object

### DIFF
--- a/Sources/AWSSDKSwift/Services/lambda/Lambda_Shapes.swift
+++ b/Sources/AWSSDKSwift/Services/lambda/Lambda_Shapes.swift
@@ -873,10 +873,11 @@ extension Lambda {
         }
 
         public init(dictionary: [String: Any]) throws {
-            self.statusCode = dictionary["StatusCode"] as? Int32
-            self.logResult = dictionary["X-Amz-Log-Result"] as? String
-            self.payload = dictionary["Payload"] as? Data
-            self.functionError = dictionary["X-Amz-Function-Error"] as? String
+            var mutableDictionary = dictionary
+            self.statusCode = mutableDictionary.removeValue(forKey: "StatusCode") as? Int32
+            self.logResult = mutableDictionary.removeValue(forKey: "X-Amz-Log-Result") as? String
+            self.functionError = mutableDictionary.removeValue(forKey: "X-Amz-Function-Error") as? String
+            self.payload = mutableDictionary["Payload"] != nil ? mutableDictionary.removeValue(forKey: "Payload") as Data? : NSKeyedArchiver.archivedData(withRootObject: mutableDictionary)
         }
     }
 


### PR DESCRIPTION
When we init with a dictionary that was a JSON object, there is no Payload. We have to move all root level objects to the payload and convert them to data

# Test Case

Create a function in AWS Lambda

**My_Function**
```
'use strict';

exports.handler = (event, context, callback) => {
    console.log('Received event: %s', JSON.stringify(event, null, 2));
    vat object = event;
    event.another = "Test";
    event.object = { "hello": "world" };
    callback(null, object);
};
```

Using this AWS CLI command with the `input.txt`, you will get the response `outputfile.txt` below.

**AWS CLI lambda command**
```
aws lambda invoke \
--invocation-type RequestResponse \
--function-name My_Function \
--region us-east-1 \
--payload file://~/input.txt \
outputfile.txt
```

**input.txt**
```
{
    "action": "start"
}
```

**Command Line Output**
```
{
    "StatusCode": 200
}
```

**outputfile.txt**
```
{
    "action": "start",
    "another": "Test",
    "object": {
        "hello": "world"
    }
}
```

Using the Lambda portion of the SDK, `.payload = nil`. We expect:

```
.payload = [    
    "action": "start"
    "another": "Test"
    "object": [
        "hello": "world"
    ]
]
```
